### PR TITLE
Added space before comment after class-name

### DIFF
--- a/src/syntax_trees/ast/interfaces/ast_visitor.php
+++ b/src/syntax_trees/ast/interfaces/ast_visitor.php
@@ -37,7 +37,7 @@
  * @version //autogen//
  * @access private
  */
-interface ezcTemplateAstNodeVisitor// extends ezcTemplateAstNodeVisitor
+interface ezcTemplateAstNodeVisitor // extends ezcTemplateAstNodeVisitor
 {
     /**
      * Visits a node containing a builtin constant type.


### PR DESCRIPTION
This fixes a problem with composer autoload generation, which parses the class-name to 'ezcTemplateAstNodeVisitor{' if a comment begins straight after the class-name.
